### PR TITLE
Set correct project start date

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can reach the maintainers of this project at:
 
 ## Kubernetes Incubator
 
-This is a [Kubernetes Incubator project](https://github.com/kubernetes/community/blob/master/incubator.md). The project was established 2006-01-02. The incubator team for the project is:
+This is a [Kubernetes Incubator project](https://github.com/kubernetes/community/blob/master/incubator.md). The project was established 2016-01-02. The incubator team for the project is:
 
 - Sponsor: Sally (@sallygithubhandle)
 - Champion: Sue (@suegithubhandle)


### PR DESCRIPTION
Previously the README stated the project started 2006-01-02. I wasn't so interested in the Kubernetes project back then, but I'm pretty sure it didn't exist at the time 😉 

Hopefully it's okay to make PRs directly against this repo.