### PR TITLE
Add steering-committe as approvers for this repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,4 +2,4 @@
 #  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
 
 approvers:
-  - philips
+  - steering-comittee

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,15 @@
+aliases:
+  steering-committee:
+    - bgrant0607
+    - brendanburns
+    - derekwaynecarr
+    - jbeda
+    - michelleN
+    - philips
+    - pwittrock
+    - quinton-hoole
+    - sarahnovotny
+    - smarterclayton
+    - spiffxp
+    - thockin
+    - timothysc


### PR DESCRIPTION
To ensure that the entire kubernetes/steering-committee team doesn't need admin access to this repo, add them as approvers

Fixes #9