### PR TITLE
Use kubernetes/community as source of truth for code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
 # Kubernetes Community Code of Conduct
 
-Please refer to our [Kubernetes Community Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md)
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,5 +1,3 @@
-## Kubernetes Community Code of Conduct
+# Kubernetes Community Code of Conduct
 
-Kubernetes follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
-
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/code-of-conduct.md?pixel)]()
+Please refer to our [Kubernetes Community Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md)


### PR DESCRIPTION
One more layer of indirection, I would prefer all of our repos refer to Kubernetes' CoC, which at the moment is a redirect to CNCF's.