### PR TITLE
Remove incubator content, touchup existing requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,8 @@
 # Contributing guidelines
 
-## How to become a contributor and submit your own code
+## Sign the CLA
 
-### Contributor License Agreements
-
-We'd love to accept your patches! Before we can take them, we have to jump a couple of legal hurdles.
-
-Please fill out either the individual or corporate Contributor License Agreement (CLA).
-
-  * If you are an individual writing original source code and you're sure you own the intellectual property, then you'll need to sign an [individual CLA](https://identity.linuxfoundation.org/node/285/node/285/individual-signup).
-  * If you work for a company that wants to allow you to contribute your work, then you'll need to sign a [corporate CLA](https://identity.linuxfoundation.org/node/285/organization-signup).
-
-Follow either of the two links above to access the appropriate CLA and instructions for how to sign and return it. Once we receive it, we'll be able to accept your pull requests.
+Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests.  Please see https://git.k8s.io/community/CLA.md for more info
 
 ### Contributing A Patch
 
@@ -20,7 +11,3 @@ Follow either of the two links above to access the appropriate CLA and instructi
 1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
 1. Fork the desired repo, develop and test your code changes.
 1. Submit a pull request.
-
-### Adding dependencies
-
-If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep). Follow the [instructions to add a dependency](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md#godep-and-dependency-management).

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
-# See the OWNERS file documentation:
-#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
 
 approvers:
   - steering-committee

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,3 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+
 aliases:
   steering-committee:
     - bgrant0607

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Kubernetes Template Project
 
-The Kubernetes Template Project is a template for starting new projects on the github.com/kubernetes organization. All Kubernetes projects, at mimimum, must have the following files:
+The Kubernetes Template Project is a template for starting new projects in the GitHub organizations owned by Kubernetes. All Kubernetes projects, at mimimum, must have the following files:
 
 - a `README.md` outlining the project goals, sponsoring sig, and community contact information
-- an `OWNERS` file with the project leads listed
+- an `OWNERS` with the project leads listed as approvers ([docs on OWNERS files](https://git.k8s.io/community/contributors/devel/owners.md))
 - a `CONTRIBUTING.md` outlining how to contribute to the project
-- a `code-of-conduct.md` outlining community behavior and the consequences of breaking the code
-- a `LICENSE` which must be Apache 2.0
-- a `RELEASE.md` file that talks about the process for releases
+- the `code-of-conduct.md` from this repo, which outlines community behavior and the consequences of breaking the code
+- a `LICENSE` which must be Apache 2.0 for code projects, or Creative Commons 4.0 for documentation repositories
 
 ## Community, discussion, contribution, and support
 
@@ -17,14 +16,6 @@ You can reach the maintainers of this project at:
 
 - [Slack](http://slack.k8s.io/)
 - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-dev)
-
-## Kubernetes Incubator
-
-This is a [Kubernetes Incubator project](https://github.com/kubernetes/community/blob/master/incubator.md). The project was established 2016-01-02. The incubator team for the project is:
-
-- Sponsor: Sally (@sallygithubhandle)
-- Champion: Sue (@suegithubhandle)
-- SIG: [sig-list](https://github.com/kubernetes/community/blob/master/sig-list.md)
 
 ### Code of conduct
 


### PR DESCRIPTION
Trying to bring this repo in alignment with the way things are today:
- we keep talking about how incubator is / should going away, so... drop wording about it?
- very few repos in kubernetes/ have RELEASE.md files
- almost every repo now uses the exact code-of-conduct.md from this repo
- [docs repos don't use the apache 2 license](https://github.com/kubernetes/community/blob/master/governance.md#repository-guidelines)
- OWNERS files point to owners docs
- remove reference to godep from CONTRIBUTING.md (not all repos are golang, not all golang repos have chosen to use that)
- link to to canonical CLA instructions at https://git.k8s.io/community/CLA.md

This is in the interest of making this repo a living example of a "correct" repo, per https://github.com/kubernetes/community/pull/1569