### PR TITLE
Specify files which cannot include custom content

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The Kubernetes Template Project is a template for starting new projects in the G
 - a `README.md` outlining the project goals, sponsoring sig, and community contact information
 - an `OWNERS` with the project leads listed as approvers ([docs on `OWNERS` files][owners])
 - a `CONTRIBUTING.md` outlining how to contribute to the project
-- the `code-of-conduct.md` from this repo, which outlines community behavior and the consequences of breaking the code
-- a `LICENSE` which must be Apache 2.0 for code projects, or Creative Commons 4.0 for documentation repositories
+- an unmodified copy of `code-of-conduct.md` from this repo, which outlines community behavior and the consequences of breaking the code
+- a `LICENSE` which must be Apache 2.0 for code projects, or [Creative Commons 4.0] for documentation repositories, without any custom content
 - a `SECURITY_CONTACTS` with the contact points for the Product Security Team 
   to reach out to for triaging and handling of incoming issues. They must agree to abide by the
   [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy) 
@@ -26,3 +26,4 @@ You can reach the maintainers of this project at:
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
 
 [owners]: https://git.k8s.io/community/contributors/guide/owners.md
+[Creative Commons 4.0]: https://git.k8s.io/website/LICENSE


### PR DESCRIPTION
@BenTheElder pointed out on slack that it would be nice to have a list of files which are allowed to have custom content and which do not.

This PR also adds a link to the Creative Commons 4.0 license from the website repo.

/committee steering

/cc @BenTheElder @spiffxp @cblecker 
/assign @spiffxp 