### PR TITLE
Update COC link

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
 # Kubernetes Community Code of Conduct
 
-Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)
+Kubernetes follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
The existing COC link points to a page that says "click here for the new link".  This PR updates the content of the template to point directly to the correct (CNCF) code of conduct.

/assign spiffxp