### PR TITLE
add instructions to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
+  # TODO: in your repo created from this template, you should replace the
+  # steering-committee with a list of project owners, see the doc linked above.
   - steering-committee

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,10 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
 
 aliases:
+  # TODO: remove this alias, it will go stale in your repo, and in your repo
+  # you should have your own set of approvers (see OWNERS)
+  # in the original template repo, we must maintain this list to approve changes
+  # to the template itself
   steering-committee:
     - bgrant0607
     - brendandburns


### PR DESCRIPTION
Per discussion in #sig-testing slack, so as to not have steering suggested as approvers in every repo, project leads should be approvers instaed.

~TODO: what should we put as the placeholder instead? I'm not sure if what I have is really suitable~
Fixed, there are TODO comments now instead.

cc @spiffxp 🧔
cc @cblecker 