### PR TITLE
Add SECURITY.md security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,22 @@
 # Security Policy
 
-## Supported Versions
+## Security Announcements
 
-Information about supported Kubernetes versions can be found on the
-[Kubernetes version and version skew support policy] page on the Kubernetes website.
+Join the [kubernetes-security-announce] group for security and vulnerability announcements.
+
+You can also subscribe to an RSS feed of the above using [this link][kubernetes-security-announce-rss].
 
 ## Reporting a Vulnerability
 
 Instructions for reporting a vulnerability can be found on the
 [Kubernetes Security and Disclosure Information] page.
 
+## Supported Versions
+
+Information about supported Kubernetes versions can be found on the
+[Kubernetes version and version skew support policy] page on the Kubernetes website.
+
+[kubernetes-security-announce]: https://groups.google.com/forum/#!forum/kubernetes-security-announce
+[kubernetes-security-announce-rss]: https://groups.google.com/forum/feed/kubernetes-security-announce/msgs/rss_v2_0.xml?num=50
 [Kubernetes version and version skew support policy]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
 [Kubernetes Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+Information about supported Kubernetes versions can be found on the
+[Kubernetes version and version skew support policy] page on the Kubernetes website.
+
+## Reporting a Vulnerability
+
+Instructions for reporting a vulnerability can be found on the
+[Kubernetes Security and Disclosure Information] page.
+
+[Kubernetes version and version skew support policy]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
+[Kubernetes Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability


### PR DESCRIPTION
Now that github has official support for security policies, some users may expect to find disclosure protocols there. We should make sure every one of our repos links the security policy to https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability to avoid accidental disclosures.

I was originally thinking of merging `SECRUITY_CONTACTS` into `SECURITY.md`, but the future of SECURITY_CONTACTS is under [active discussion](https://groups.google.com/d/topic/kubernetes-sig-architecture/0MUJBDGf3jg/discussion). I'm also worried that people looking for who to contact might reach out to security contacts rather than following our disclosure process (part of the larger discussion).