### PR TITLE
Update dev@ mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Learn how to engage with the Kubernetes community on the [community page](http:/
 
 You can reach the maintainers of this project at:
 
-- [Slack](http://slack.k8s.io/)
-- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-dev)
+- [Slack](https://slack.k8s.io/)
+- [Mailing List](https://groups.google.com/a/kubernetes.io/g/dev)
 
 ### Code of conduct
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,4 +6,4 @@ The Kubernetes Template Project is released on an as-needed basis. The process i
 1. All [OWNERS](OWNERS) must LGTM this release
 1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
 1. The release issue is closed
-1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`
+1. An announcement email is sent to `dev@kubernetes.io` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`


### PR DESCRIPTION
The mailing list `kubernetes-dev@googlegroups.com` is migrated to `dev@kubernetes.io`.